### PR TITLE
Three changes, August 2017

### DIFF
--- a/src/assessment.handlebars
+++ b/src/assessment.handlebars
@@ -621,6 +621,7 @@
         <li>Contribution-based, which is based on you having paid enough National Insurance contributions</li>
       </ul>
       <p>The type of ESA you get will depend on a range of factors that we cover at the end of this guide. </p>
+      <p>In some parts of the country you can no longer make a new claim for income- related ESA, instead you have to claim Universal Credit. Eventually, Universal Credit will replace income-related ESA everywhere. This guide does not provide details about Universal Credit.</p>
       <h3>The Application Process</h3>
       <h4>Your application will involve the following stages:</h4>
       <ul>
@@ -991,10 +992,12 @@
       <p><strong>Income-related ESA</strong> is paid to people whose income (looking at their income and their partners&#39;) and level of savings is low enough. What you receive is decided by the Government working out how much you need to live on, and paying you ESA to make up your income to that amount. In some circumstances income-related ESA may also be used to top up your contribution-based ESA.</p>
       <p>You cannot claim income-related ESA if you have savings of over &#xA3;16,000, or your partner works more than 24 hours per week.</p>
       <p>You can claim income-related ESA without time limit, although you may of course have your entitlement to ESA reassessed at some point.</p>
+      <p>In some parts of the country you can no longer make a new claim for income- related ESA, instead you claim Universal Credit. Eventually, Universal Credit will replace income-related ESA everywhere. This guide does not provide details about Universal Credit which you usually have to claim on-line. One of the places you can <a href="https://www.gov.uk/universal-credit" target="_top">find out more information about Universal Credit is the government's own website.</a></p>
       <h3>Payment Rates</h3>
       <p>Working out how much ESA you are entitled to claim can be complicated, particularly if you are claiming income based ESA. What follows is the most basic information that we can provide.</p>
       <p>Whilst you are in the assessment process you will be claiming the assessment or basic rate of ESA. This is usually paid at &#xA3;57.90 per week if you are under 25, &#xA3;73.90 per week if you are over 25. </p>
       <p>Once you have your decision, if you are being paid contribution-based ESA, you will be paid an additional &#xA3;29.05 on top of the assessment rate if you are in the work related activity group, and &#xA3;36.20 if you are in the Support Group. </p>
+      Once you have your decision, if you are being paid contribution-based ESA, you will be paid an additional &#xA3;36.20 if you are in the Support Group. Some people in the ESA work-related activity group may get more than the basic amount if they applied before 3 April 2017.
       <p>If you&#39;re in the support group and on income-related ESA, you&#39;re also entitled to the Enhanced Disability Premium at &#xA3;15.75 a week.</p>
       <p>The calculation of how much income-related ESA you should receive is more complex, and depends on your household income, whether you live with a partner, how old you (and your partner are), and whether you are a single parent.</p>
       <h3>Reassessment</h3>


### PR DESCRIPTION
After "The type of ESA you get will depend on a range of factors that we cover at the end of this guide.", add "In some parts of the country you can no longer make a new claim for income- related ESA, instead you have to claim Universal Credit. Eventually, Universal Credit will replace income-related ESA everywhere. This guide does not provide details about Universal Credit."

After "You can claim income-related ESA without time limit, although you may of course have your entitlement to ESA reassessed at some point.", add "In some parts of the country you can no longer make a new claim for income- related ESA, instead you claim Universal Credit. Eventually, Universal Credit will replace income-related ESA everywhere. This guide does not provide details about Universal Credit which you usually have to claim on-line. One of the place you can find out more information about Universal Credit is Gov.UK by using this link <https://www.gov.uk/universal-credit>"

Replace para on payments rates with "Once you have your decision, if you are being paid contribution-based ESA, you will be paid an additional £36.20 if you are in the Support Group. Some people in the ESA work-related activity group may get more than the basic amount if they applied before 3 April 2017."